### PR TITLE
Fix parsing of content containing `html` and `value` properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function ptd(mf2) {
     Array.isArray(mf2.properties[property]) &&
     typeof mf2.properties[property][0] !== 'undefined' &&
     mf2.properties[property][0] !== null &&
-    mf2.properties[property][0].trim() !== '';
+    mf2.properties[property].map(s => s !== '');
 
   // Get the main content of the post
   let content = null;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -23,12 +23,91 @@ test('note with name post type discovery', () => {
   expect(type).toBe('note');
 });
 
+test('note with summary post type discovery', () => {
+  const mf2 = {
+    type: ['h-entry'],
+    properties: {
+      name: ['Title'],
+      summary: ['Note summary'],
+    },
+  };
+  const type = ptd(mf2);
+  expect(type).toBe('note');
+});
+
 test('article post type discovery', () => {
   const mf2 = {
     type: ['h-entry'],
     properties: {
       name: ['Title'],
       content: ['content'],
+    },
+  };
+  const type = ptd(mf2);
+  expect(type).toBe('article');
+});
+
+test('article with HTML post type discovery', () => {
+  const mf2 = {
+    type: ['h-entry'],
+    properties: {
+      name: ['Title'],
+      content: [
+        {
+          html: '<p>Content in <em>HTML</em> format.</p>',
+        },
+      ],
+    },
+  };
+  const type = ptd(mf2);
+  expect(type).toBe('article');
+});
+
+test('article with plain text post type discovery', () => {
+  const mf2 = {
+    type: ['h-entry'],
+    properties: {
+      name: ['Title'],
+      content: [
+        {
+          value: 'Content in _Markdown_ format.',
+        },
+      ],
+    },
+  };
+  const type = ptd(mf2);
+  expect(type).toBe('article');
+});
+
+test('article with HTML and plain text post type discovery', () => {
+  const mf2 = {
+    type: ['h-entry'],
+    properties: {
+      name: ['Title'],
+      content: [
+        {
+          html: '<p>Content in <em>HTML</em> format.</p>',
+          value: 'Content in _Markdown_ format.',
+        },
+      ],
+    },
+  };
+  const type = ptd(mf2);
+  expect(type).toBe('article');
+});
+
+test('article with summary post type discovery', () => {
+  const mf2 = {
+    type: ['h-entry'],
+    properties: {
+      name: ['Title'],
+      summary: ['Summary of content'],
+      content: [
+        {
+          html: '<p>Content</p>',
+          value: 'Content',
+        },
+      ],
     },
   };
   const type = ptd(mf2);


### PR DESCRIPTION
Hi Grant!

I’ve finally got round to using this module in my own project, but unfortunately it threw an error encountering `content` properties containing `html` and `value`, i.e.:

``` js
content: {
  html: '<p>Content is <em>cool</em></p>',
  value: 'Content is _cool_'
}
```

I’m not sure if my suggested change (trimming the items in a mapped array) is the correct one, but it’s the change that passed the unit tests! Speaking of which, I’ve added tests for:

* Posts that include a `summary` property
* Posts whose `content` property provides `value` only
* Posts whose `content` property provides `html` only
* Posts whose `content` property provides `html` and `value`.

With these in place, the code reaches near-as-damn-it 100% test coverage 🎉